### PR TITLE
BUGFIX: Duplicação dos resultados quando ocorria o duplo clique

### DIFF
--- a/plugin-prototipo/assets/index.html
+++ b/plugin-prototipo/assets/index.html
@@ -47,7 +47,7 @@
             <textarea name="descricao" id="descricao" rows="3" cols="70" placeholder="Descrição ..." required></textarea>
 
             <input type="text" id="searchInputForm">
-            <button type="submit" onclick="return searchButtonClickedForm()" class="button_search">Pesquisar</button>
+            <button type="button" onclick="return searchButtonClickedForm()" class="button_search">Pesquisar</button>
             <div id="listaResultadosForms"></div>
             <div id="mapaFormulario" style="height: 300px;margin-bottom:10px;"></div>
 

--- a/plugin-prototipo/assets/js/script.js
+++ b/plugin-prototipo/assets/js/script.js
@@ -4,8 +4,8 @@ var mapFormulario;
 var mapAdmin;
 var map_exit;
 var resultados = []; // Array para armazenar os locais relacionados
-var isSearchingIndex = false;
-var isSearchingForm = false;
+var isSearchingIndex = false; // Status de busca no index
+var isSearchingForm = false; // Status de busca no form
 
 
 
@@ -53,36 +53,8 @@ document.addEventListener('DOMContentLoaded', function () {
         }
     });
 });
+
 // CRIANDO MAPAS
-
-function initMap() {
-    if (document.getElementById('mapa') == null) {
-        return;
-    }
-
-    map = L.map('mapa', { doubleClickZoom: false }).setView([-15.8267, -47.9218], 13);
-
-    // Adiciona o provedor de mapa OpenStreetMap
-    L.tileLayer('https://{s}.tile.openstreetmap.org/{z}/{x}/{y}.png', {
-        attribution: '&copy; <a href="https://www.openstreetmap.org/copyright">OpenStreetMap</a> contributors'
-    }).addTo(map);
-
-    getLocation(map);
-
-    formularios_aprovados.forEach(function (formulario) {
-        // Cria o conteúdo HTML personalizado para o pop-up (Nome e Descrição)
-        var popupContent = `
-            <div>
-                <h4>Nome do Local:${formulario.nome}</h4>
-                <p><strong>Descrição:</strong> ${formulario.descricao}</p>
-            </div>
-        `;
-
-        L.marker([formulario.latitude, formulario.longitude])
-            .bindPopup(popupContent)
-            .addTo(map);
-    });
-}
 
 function initMap() {
     map = L.map('mapa', { doubleClickZoom: false }).setView([-15.8267, -47.9218], 13);
@@ -305,6 +277,7 @@ function getLocation(mapa) {
     document.getElementById('latitude').value = '';
     document.getElementById('longitude').value = '';
 }
+
 // Função para mostrar a posição do usuário no mapa
 function showPosition(position, mapa) {
     var lat = position.coords.latitude; // Latitude
@@ -325,7 +298,6 @@ function showPosition(position, mapa) {
 // Chama initMap() quando a página for carregada
 window.onload = function () {
     initMap();
-    initMapAdmin();
 };
 
 // Função que permite voltar da tela final para a tela inicial
@@ -374,6 +346,7 @@ function searchButtonClickedForm() {
         var searchTerm = document.getElementById('searchInputForm').value;
         searchLocations(searchTerm, 'listaResultadosForms');
     }
+    return false;
 }
 
 function searchLocations(query, resultListId) {

--- a/plugin-prototipo/assets/js/script.js
+++ b/plugin-prototipo/assets/js/script.js
@@ -1,10 +1,11 @@
-// Inicializa o mapa quando a página for carregada
 var map;
 var marcador;
 var mapFormulario;
 var mapAdmin
 var map_exit;
 var resultados = []; // Array para armazenar os locais relacionados
+var isSearchingIndex = false;
+var isSearchingForm = false;
 
 // Função para destacar uma determinada linha na tabela de formulários aprovados
 function destacarLinhaTabela(id) {
@@ -320,20 +321,24 @@ function updateSelectValue(){
 document.getElementById("meu_formulario").addEventListener("submit",updateSelectValue);
 
 function searchButtonClicked() {
-    var searchTerm = document.getElementById('searchInputIndex').value;
-    resultados = [];
-    searchLocations(searchTerm, 'listaResultadosIndex');
+    if (!isSearchingIndex) {
+        isSearchingIndex = true;
+        var searchTerm = document.getElementById('searchInputIndex').value;
+        searchLocations(searchTerm, 'listaResultadosIndex');
+    }
     return false;
 }
 
 function searchButtonClickedForm() {
-    var searchTerm = document.getElementById('searchInputForm').value;
-    resultados = [];
-    searchLocations(searchTerm, 'listaResultadosForms');
-    return false;
+    if (!isSearchingForm) {
+        isSearchingForm = true;
+        var searchTerm = document.getElementById('searchInputForm').value;
+        searchLocations(searchTerm, 'listaResultadosForms');
+    }
 }
 
 function searchLocations(query, resultListId) {
+    resultados = [];
     var apiUrl = 'https://nominatim.openstreetmap.org/search?format=json&q=' + encodeURIComponent(query);
     fetch(apiUrl)
         .then(response => response.json())
@@ -346,8 +351,24 @@ function searchLocations(query, resultListId) {
                 });
             });
             imprimirResultados(resultados, resultListId);
+            
+            // Atualiza o estado da busca após a conclusão
+            if (resultListId === 'listaResultadosIndex') {
+                isSearchingIndex = false; // Marca a busca na página inicial como concluída
+            } else if (resultListId === 'listaResultadosForms') {
+                isSearchingForm = false; // Marca a busca no formulário como concluída
+            }
         })
-        .catch(error => console.error('Erro ao buscar locais:', error));
+        .catch(error => {
+            console.error('Erro ao buscar locais:', error);
+            
+            // Em caso de erro, atualiza o estado da busca para permitir novas buscas
+            if (resultListId === 'listaResultadosIndex') {
+                isSearchingIndex = false; // Marca a busca na página inicial como concluída
+            } else if (resultListId === 'listaResultadosForms') {
+                isSearchingForm = false; // Marca a busca no formulário como concluída
+            }
+        });
 }
 
 function imprimirResultados(resultados, resultListId) {

--- a/plugin-prototipo/includes/admin/admin_script.js
+++ b/plugin-prototipo/includes/admin/admin_script.js
@@ -1,3 +1,7 @@
+window.onload = function () {
+    initMapAdmin();
+};
+
 function mostrarDescricaoCompleta(id) {
     var descricaoResumida = document.getElementById('descricaoResumida_' + id);
     var descricaoCompleta = document.getElementById('descricaoCompleta_' + id);


### PR DESCRIPTION
# O que há de novo?
Agora os campos de busca quando ocorre duas ou mais requisições rápidas (duplo click) os resultados não são duplicados.

**Tipo da mudança**  

Marque o checkbox correspondente a mudança. 
- [ ] Mudança na documentação
- [ ] Novo arquivo (funcionabilidade nova)
- [ ] Edição de arquivo (alteração de funcionalidade)
- [x] Correção de bug (sem alterações de funcionalidade)
- [ ] Adição de nova fucionalidade.
- [ ] Não se aplica.

**Descrição da mudança**

Adicionado algumas variáveis de status para cada busca (tela inicial e formulário) elas param uma nova busca caso outra esteja ainda em andamento.

**Issue relacionada**  

 - #91
