### PR TITLE
Adicionando o tratamento de resultados das buscas

### DIFF
--- a/lgbtq_connect/assets/js/funcionalidades.js
+++ b/lgbtq_connect/assets/js/funcionalidades.js
@@ -80,43 +80,46 @@ function imprimirResultados(resultados, resultListId) {
         } 
     });
     
+
     listaResultados.appendChild(div);
 
-    // Adicionando botão "Ver Mais"
-    var verMaisButton = document.createElement('button');
-    verMaisButton.textContent = 'Ver Mais';
-    verMaisButton.addEventListener('click', function() {
-        MostrarMaisResultados();
-    });
-    
-    listaResultados.appendChild(verMaisButton);
-    
-    // Adicionando botão "Ver Menos"
-    var verMenosButton = document.createElement('button');
-    verMenosButton.textContent = 'Ver Menos';
-    verMenosButton.addEventListener('click', function() {
-        MostrarMenosResultados();
-    });
-    verMenosButton.style.display = 'none';
-
-    listaResultados.appendChild(verMenosButton);
-
-    // Função para mostrar mais resultados
-    function MostrarMaisResultados() {
-        listaResultadosOcultados.forEach(resultado => {
-            resultado.style.display = 'block';
+    if (count > 5){
+        // Adicionando botão "Ver Mais"
+        var verMaisButton = document.createElement('button');
+        verMaisButton.textContent = 'Ver Mais';
+        verMaisButton.addEventListener('click', function() {
+            MostrarMaisResultados();
         });
-        verMaisButton.style.display = 'none';
-        verMenosButton.style.display = 'block';
-    }
-
-    // Função para mostrar menos resultados
-    function MostrarMenosResultados() {
-        listaResultadosOcultados.forEach(resultado => {
-            resultado.style.display = 'none';
+        
+        listaResultados.appendChild(verMaisButton);
+        
+        // Adicionando botão "Ver Menos"
+        var verMenosButton = document.createElement('button');
+        verMenosButton.textContent = 'Ver Menos';
+        verMenosButton.addEventListener('click', function() {
+            MostrarMenosResultados();
         });
-        verMaisButton.style.display = 'block';
         verMenosButton.style.display = 'none';
+
+        listaResultados.appendChild(verMenosButton);
+
+        // Função para mostrar mais resultados
+        function MostrarMaisResultados() {
+            listaResultadosOcultados.forEach(resultado => {
+                resultado.style.display = 'block';
+            });
+            verMaisButton.style.display = 'none';
+            verMenosButton.style.display = 'block';
+        }
+
+        // Função para mostrar menos resultados
+        function MostrarMenosResultados() {
+            listaResultadosOcultados.forEach(resultado => {
+                resultado.style.display = 'none';
+            });
+            verMaisButton.style.display = 'block';
+            verMenosButton.style.display = 'none';
+        }
     }
 }
 

--- a/lgbtq_connect/assets/js/funcionalidades.js
+++ b/lgbtq_connect/assets/js/funcionalidades.js
@@ -80,22 +80,44 @@ function imprimirResultados(resultados, resultListId) {
         } 
     });
     
+    listaResultados.appendChild(div);
+
     // Adicionando botão "Ver Mais"
     var verMaisButton = document.createElement('button');
     verMaisButton.textContent = 'Ver Mais';
     verMaisButton.addEventListener('click', function() {
-        showMoreResults();
+        MostrarMaisResultados();
     });
-
+    
     listaResultados.appendChild(verMaisButton);
+    
+    // Adicionando botão "Ver Menos"
+    var verMenosButton = document.createElement('button');
+    verMenosButton.textContent = 'Ver Menos';
+    verMenosButton.addEventListener('click', function() {
+        MostrarMenosResultados();
+    });
+    verMenosButton.style.display = 'none';
+
+    listaResultados.appendChild(verMenosButton);
 
     // Função para mostrar mais resultados
-    function showMoreResults() {
+    function MostrarMaisResultados() {
         listaResultadosOcultados.forEach(resultado => {
             resultado.style.display = 'block';
         });
+        verMaisButton.style.display = 'none';
+        verMenosButton.style.display = 'block';
     }
-    listaResultados.appendChild(div);
+
+    // Função para mostrar menos resultados
+    function MostrarMenosResultados() {
+        listaResultadosOcultados.forEach(resultado => {
+            resultado.style.display = 'none';
+        });
+        verMaisButton.style.display = 'block';
+        verMenosButton.style.display = 'none';
+    }
 }
 
 function changeMapLocation(latitude, longitude) {

--- a/lgbtq_connect/assets/js/funcionalidades.js
+++ b/lgbtq_connect/assets/js/funcionalidades.js
@@ -87,6 +87,7 @@ function imprimirResultados(resultados, resultListId) {
         // Adicionando botão "Ver Mais"
         var verMaisButton = document.createElement('button');
         verMaisButton.textContent = 'Ver Mais';
+        verMaisButton.setAttribute('type', 'button');
         verMaisButton.addEventListener('click', function() {
             MostrarMaisResultados();
         });
@@ -96,6 +97,7 @@ function imprimirResultados(resultados, resultListId) {
         // Adicionando botão "Ver Menos"
         var verMenosButton = document.createElement('button');
         verMenosButton.textContent = 'Ver Menos';
+        verMenosButton.setAttribute('type', 'button');
         verMenosButton.addEventListener('click', function() {
             MostrarMenosResultados();
         });

--- a/lgbtq_connect/assets/js/funcionalidades.js
+++ b/lgbtq_connect/assets/js/funcionalidades.js
@@ -55,8 +55,10 @@ function searchLocations(query, resultListId) {
 }
 
 function imprimirResultados(resultados, resultListId) {
+    var listaResultadosOcultados = [];
     var listaResultados = document.getElementById(resultListId);
     listaResultados.innerHTML = '';
+    var count = 0;
     var div = document.createElement('div');
     resultados.forEach(resultado => {
         var divResultado = document.createElement('div');
@@ -68,8 +70,31 @@ function imprimirResultados(resultados, resultListId) {
         divResultado.addEventListener('click', function () {
             changeMapLocation(resultado.lat, resultado.lon);
         });
-        div.appendChild(divResultado);
+        count += 1;
+        if(count <=5){
+            div.appendChild(divResultado);
+        } else {
+            divResultado.style.display = 'none';
+            listaResultadosOcultados.push(divResultado);
+            div.appendChild(divResultado);
+        } 
     });
+    
+    // Adicionando botão "Ver Mais"
+    var verMaisButton = document.createElement('button');
+    verMaisButton.textContent = 'Ver Mais';
+    verMaisButton.addEventListener('click', function() {
+        showMoreResults();
+    });
+
+    listaResultados.appendChild(verMaisButton);
+
+    // Função para mostrar mais resultados
+    function showMoreResults() {
+        listaResultadosOcultados.forEach(resultado => {
+            resultado.style.display = 'block';
+        });
+    }
     listaResultados.appendChild(div);
 }
 


### PR DESCRIPTION
# O que há de novo?
Os resultados dos campos de busca agora são reduzidos a cinco e foram adicionados os (botões de ver mais e ver menos) para auxiliar o usuário no uso da ferramenta.
 
## Qual a alteração que exige um pull request?
A funcionalidade de manipulação dos resultados de busca para melhorar a visualização dos resultados.

**Tipo da mudança**  

Marque o checkbox correspondente a mudança. 
- [ ] Mudança na documentação
- [ ] Novo arquivo (funcionabilidade nova)
- [x] Edição de arquivo (alteração de funcionalidade)
- [ ] Correção de bug (sem alterações de funcionalidade)
- [x] Adição de nova fucionalidade.
- [ ] Não se aplica.

**Descrição da mudança**
Foram limitadas os resultados das buscas para 5, em caso de necessidade os botões de ver mais e ver menos auxiliam na visualização dos resultados, buscando uma visualização mais armônica.

**Issue relacionada**  

- #15 


**Screenshots**  
 
![Captura de tela de 2024-05-02 15-43-40](https://github.com/ResidenciaTICBrisa/T2G8-Plugin-Wordpress/assets/124713089/bcc482b1-b829-448a-91a0-9c024205a894)


![Captura de tela de 2024-05-02 15-44-09](https://github.com/ResidenciaTICBrisa/T2G8-Plugin-Wordpress/assets/124713089/d3d4f0d7-100c-4c57-bd04-fe9b73c901e2)



