### PR TITLE
Estilização dos botões de ver mais e ver menos das pesquisas

### DIFF
--- a/lgbtq_connect/assets/js/funcionalidades.js
+++ b/lgbtq_connect/assets/js/funcionalidades.js
@@ -88,6 +88,7 @@ function imprimirResultados(resultados, resultListId) {
         var verMaisButton = document.createElement('button');
         verMaisButton.textContent = 'Ver Mais';
         verMaisButton.setAttribute('type', 'button');
+        verMaisButton.setAttribute('class', 'ver');
         verMaisButton.addEventListener('click', function() {
             MostrarMaisResultados();
         });
@@ -98,6 +99,7 @@ function imprimirResultados(resultados, resultListId) {
         var verMenosButton = document.createElement('button');
         verMenosButton.textContent = 'Ver Menos';
         verMenosButton.setAttribute('type', 'button');
+        verMenosButton.setAttribute('class', 'ver');
         verMenosButton.addEventListener('click', function() {
             MostrarMenosResultados();
         });

--- a/lgbtq_connect/assets/styles/styles.css
+++ b/lgbtq_connect/assets/styles/styles.css
@@ -27,15 +27,23 @@
     border-radius: 10px;
     color:white;
     text-align:center;
+    align-items: center;
 }
 
-.button_search, .ver{
+.button_search{
     width: 17%;
 }
 
 .ver {
     margin: auto;
     display : block;
+    width: 10%;
+    height: 20px;
+    justify-content: center;
+    align-items: center;
+    border-radius: 5px;
+    font-size: 0.75rem;
+    padding: 0px;
 }
 
 .blue_button:hover, .button_search:hover, .ver:hover{

--- a/lgbtq_connect/assets/styles/styles.css
+++ b/lgbtq_connect/assets/styles/styles.css
@@ -19,7 +19,7 @@
     margin-bottom:10px;
 }
 
-.blue_button, .button_search{
+.blue_button, .button_search, .ver{
     width:100%;
     background-color: #2a75f3;
     padding:10px;
@@ -29,11 +29,16 @@
     text-align:center;
 }
 
-.button_search{
+.button_search, .ver{
     width: 17%;
 }
 
-.blue_button:hover, .button_search:hover{
+.ver {
+    margin: auto;
+    display : block;
+}
+
+.blue_button:hover, .button_search:hover, .ver:hover{
     background-color: #1266f1;
 }
 


### PR DESCRIPTION
# O que há de novo?
Os botões de ver mais e ver menos tiveram sua aparência modificada.
 
## Qual a alteração que exige um pull request?
A modificação da aparência dos botões para um melhor encaixe na identidade visual do projeto.

**Tipo da mudança**  

Marque o checkbox correspondente a mudança. 
- [ ] Mudança na documentação
- [ ] Novo arquivo (funcionabilidade nova)
- [x] Edição de arquivo (alteração de funcionalidade)
- [ ] Correção de bug (sem alterações de funcionalidade)
- [ ] Adição de nova fucionalidade.
- [ ] Não se aplica.

**Descrição da mudança**
Os botões de ver mais e ver menos das pesquisas por locais tiveram suas cores modificadas e foram centralizados com o objetivo de alcançar uma harmonia visual com os outros elementos. 

**Issue relacionada**  

- #113  


**Screenshots**  
 
![image](https://github.com/ResidenciaTICBrisa/T2G8-Plugin-Wordpress/assets/85762681/4a693ec1-07e4-441a-8548-3ba169b1de23)
![image](https://github.com/ResidenciaTICBrisa/T2G8-Plugin-Wordpress/assets/85762681/32f44846-109f-4e3b-9b33-9fc324d5411c)