### PR TITLE
Feat: Adicao do bloco do plugin no editor de blocos do wordpress

### DIFF
--- a/lgbtq_connect/assets/js/block.js
+++ b/lgbtq_connect/assets/js/block.js
@@ -1,0 +1,16 @@
+( function( blocks, element ) {
+    var el = element.createElement;
+
+    blocks.registerBlockType( 'lgbtq-connect/custom-block', {
+        title: 'LGBTQ+ Connect',
+        icon: 'location',
+        category: 'widgets',
+        edit: function( props ) {
+            return el(
+                'div',
+                { className: `${props.className} gradient-border`},
+                '(Local onde o mapa LGBTQ+ Connect será exibido)'
+            );
+        },
+    } );
+} )( window.wp.blocks, window.wp.element );

--- a/lgbtq_connect/assets/styles/block_style.css
+++ b/lgbtq_connect/assets/styles/block_style.css
@@ -1,0 +1,21 @@
+/* block-editor.css */
+.gradient-border {
+    background-color: transparent;
+    font-weight: 500;
+    padding: 15px;
+    transform-style: preserve-3d;
+    perspective: 2000px;
+    text-align: center;
+    &:before{
+        content: '';
+        position: absolute;
+        top: 0;
+        left: 0;
+        width: 100%;
+        height: 100%;
+        background: transparent;
+        border: 3.5px solid #fff;
+        box-sizing: border-box;
+        border-image: linear-gradient(to right, rgb(229, 0, 0), rgb(255, 141, 0), rgb(255, 238, 0), rgb(2, 129, 33), rgb(0, 76, 255), rgb(119, 0, 136)) 1;
+    }
+}

--- a/lgbtq_connect/index.php
+++ b/lgbtq_connect/index.php
@@ -2,7 +2,7 @@
 /*
 Plugin Name: LGBTQ+ Connect
 Plugin URI: https://residenciaticbrisa.github.io/T2G8-Plugin-Wordpress/
-Description: Mapa LGBTQ+ com cadastro e validação admin, promovendo locais acolhedores para a comunidade
+Description: Adição de mapa com cadastro e validação, promovendo locais acolhedores para a comunidade LGBTQ+.
 Version: 0.34.0
 Author: Igor Brandão, Gustavo Linhares, Marcos Vinicius, Max Rohrer e Will Bernardo
 License: GPL v2 or later
@@ -99,7 +99,7 @@ add_action('admin_enqueue_scripts', 'enfileirar_scripts_admin');
 add_action('admin_enqueue_scripts', 'enfileirar_styles_admin');
 
 // Função para adicionar o shortcode
-function meu_plugin_shortcode() {
+function lc_shortcode() {
     // Obtém o conteúdo do arquivo HTML
     $html_content = load_meu_plugin_html();
     enfileirar_scripts();
@@ -110,5 +110,31 @@ function meu_plugin_shortcode() {
     return $html_content;
 }
 
-// Registra o shortcode com o nome 'meu_plugin'
-add_shortcode('lgbtq_connect', 'meu_plugin_shortcode');
+// Registra o shortcode com o nome 'lgbtq_connect'
+add_shortcode('lgbtq_connect', 'lc_shortcode');
+
+function lc_register_block() {
+    // Registra o script do bloco
+    wp_register_script(
+        'lgbtq-connect-block',
+        plugins_url('/assets/js/block.js', __FILE__),
+        array('wp-blocks', 'wp-element', 'wp-editor'),
+        filemtime(plugin_dir_path(__FILE__) . '/assets/js/block.js')
+    );
+
+
+    wp_register_style(
+        'lgbtq-connect-block-editor',
+        plugins_url('/assets/styles/block_style.css', __FILE__),
+        array('wp-edit-blocks'),
+        filemtime(plugin_dir_path(__FILE__) . '/assets/styles/block_style.css')
+    );
+
+    // Registra o bloco
+    register_block_type('lgbtq-connect/custom-block', array(
+        'editor_script' => 'lgbtq-connect-block',
+        'editor_style'  => 'lgbtq-connect-block-editor',
+        'render_callback' => 'lc_shortcode',
+    ));
+}
+add_action('init', 'lc_register_block');


### PR DESCRIPTION
# O que há de novo?
Adição do bloco LGBTQ+ Connect no editor de blocos do wordpress, no qual auxilia na adição das telas do plugin nas páginas.

**Tipo da mudança**  

Marque o checkbox correspondente a mudança. 
- [ ] Mudança na documentação
- [x] Funcionabilidade nova
- [x] Alteração de funcionalidade
- [ ] Correção de bug
- [ ] Não se aplica.

**Descrição da mudança**

Foi adicionada o bloco do plugin no editor de blocos, além de pequenas alteações no index do plugin visando melhor escrita dos códigos

**Issue relacionada**  

- #210 

**Screenshots**  
 
 - Bloco do plugin no editor de blocos do wordpress
![Captura de tela de 2024-08-08 17-30-10](https://github.com/user-attachments/assets/4c504a0b-6384-4bb7-9510-244b3110cd06)

- Tela de auxílio para mostrar onde as telas são adicionadas
![Captura de tela de 2024-08-08 17-30-39](https://github.com/user-attachments/assets/8cd934f9-9caf-4d15-99cd-f8b5334467da)



